### PR TITLE
Use more reliable way of animations disabling

### DIFF
--- a/Source/Ariadne/RootViewTransition.swift
+++ b/Source/Ariadne/RootViewTransition.swift
@@ -67,16 +67,15 @@ open class RootViewTransition: ViewTransition {
     ///   - completion: Called once transition has been completed.
     open func perform(with view: ViewController?, on visibleView: ViewController?, completion: ((Bool) -> Void)?) {
         if isAnimated {
-            let oldState = UIView.areAnimationsEnabled
-            UIView.setAnimationsEnabled(false)
-            UIView.transition(with: window, duration: duration,
-                              options: animationOptions,
-                              animations: {
-                self.window.rootViewController = view
-            }, completion: { state in
-                UIView.setAnimationsEnabled(oldState)
-                completion?(state)
-            })
+            UIView.performWithoutAnimation {
+                UIView.transition(with: window, duration: duration,
+                                  options: animationOptions,
+                                  animations: {
+                    self.window.rootViewController = view
+                }, completion: { state in
+                    completion?(state)
+                })
+            }
         } else {
             window.rootViewController = view
             completion?(true)


### PR DESCRIPTION
Existing implementation is vulnerable to race condition - when this transition is run twice almost at the same time, the second transition will use false as oldState and will permanently disable animations for entire app.